### PR TITLE
normalize the lookup name so that it works on Windows

### DIFF
--- a/lib/create-custom-compiler-class.js
+++ b/lib/create-custom-compiler-class.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const Handlebars = require('handlebars');
 
 const cache = require('./cache');
@@ -19,6 +20,7 @@ module.exports = function createCustomCompiler() {
   CustomCompiler.prototype = Object.create(JavaScriptCompiler.prototype);
   CustomCompiler.prototype.compiler = CustomCompiler;
   CustomCompiler.prototype.nameLookup = function(parent, name, type) {
+    name = path.normalize(name);
     if (type === 'partial') {
       if (name === '@partial-block') {
         return JavaScriptCompiler.prototype.nameLookup.apply(this, arguments);


### PR DESCRIPTION
Hi @tylergould , our developers found some errors on running unit tests on windows. Root cause is that it can not resolve the partials correctly on windows. for example, in our handlebars template, we have a lot of code as following. as you can see path is forward slash. however in fina-partials.js all the found partias with be cached under the name with OS specific path separator which will be common\\templates\\detail on windows). So I create a pull request to normalize the name before lookup. could you help merge it? Thanks for your time. 
```
<div>
    {{> common/templates/reusableTemplates}}
</div>
```