### PR TITLE
Add support for configuring helper filename extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Configure the transformer in a `handlebars-jest` property in your Jest config's 
           "/some/absolute/path/to/helpers",
           "<rootDir>/another/helpers/path"
         ],
+        "helperExtensions": [
+          ".js",
+          ".mjs"
+        ],
         "partialDirs": [
           "/some/absolute/path/to/partials",
           "<rootDir>/another/partials/path"
@@ -55,5 +59,6 @@ Configure the transformer in a `handlebars-jest` property in your Jest config's 
 The following options are supported:
 
 - *helperDirs*: Defines directories to be searched for helpers.
+- *helperExtensions*: Defines valid filename extensions for helpers. Default is `['.js']`.
 - *partialDirs*: Defines directories to be searched for partials.
 - *partialExtensions*: Defines valid filename extensions for partials. Default is `['.hbs', '.handlebars']`.

--- a/__tests__/lib/create-custom-compiler-class.spec.js
+++ b/__tests__/lib/create-custom-compiler-class.spec.js
@@ -21,6 +21,7 @@ describe('CustomCompiler', function() {
 
     const CustomCompiler = createCustomCompilerClass({
       helperDirs: ['/some/path'],
+      helperExtensions: ['.mjs'],
       partialDirs: ['/other/path'],
       partialExtensions: ['.html']
     });

--- a/__tests__/lib/find-helpers.spec.js
+++ b/__tests__/lib/find-helpers.spec.js
@@ -42,7 +42,7 @@ describe('findHelpers', function() {
     expect(result).toEqual({});
   });
 
-  test('only finds js', function() {
+  test('only finds js when using default extensions', function() {
     const intendedPath = '/path/to/helpers';
     mock({
       [intendedPath]: {
@@ -53,6 +53,24 @@ describe('findHelpers', function() {
     const result = findHelpers([intendedPath]);
     expect(console.warn.mock.calls.length).toEqual(1);
     expect(result).toEqual({});
+  });
+
+  test('finds mjs files using custom extensions', function() {
+    const intendedPath = '/path/to/helpers';
+    mock({
+      [intendedPath]: {
+        'myhelper.mjs': 'helper using nonstandard extension',
+        'nolongerfound.js': 'helper with default extension which has been overridden',
+      }
+    });
+
+    const expectedResult = {
+        'myhelper': '/path/to/helpers/myhelper.mjs'
+    };
+
+    const result = findHelpers([intendedPath], null, ['.mjs']);
+    expect(console.warn.mock.calls.length).toEqual(1);
+    expect(result).toEqual(expectedResult);
   });
 
   test('subsequent calls use cache', function() {
@@ -110,8 +128,8 @@ describe('findHelpers', function() {
       firstHelper: `${intendedPath}/firstHelper.js`,
       secondHelper: `${intendedPath}/secondHelper.js`
     };
-    
-    
+
+
     // When
     const helpers = findHelpers([configuredPath], rootDir);
 

--- a/lib/create-custom-compiler-class.js
+++ b/lib/create-custom-compiler-class.js
@@ -8,7 +8,7 @@ const getHandlebarsJestConfig = require('./get-handlebars-jest-config');
 
 module.exports = function createCustomCompiler() {
   const config = getHandlebarsJestConfig();
-  const foundHelpers = findHelpers(config.helperDirs, config.rootDir);
+  const foundHelpers = findHelpers(config.helperDirs, config.rootDir, config.helperExtensions);
   const foundPartials = findPartials(config.partialDirs, config.rootDir, config.partialExtensions);
 
   const JavaScriptCompiler = Handlebars.JavaScriptCompiler;

--- a/lib/find-helpers.js
+++ b/lib/find-helpers.js
@@ -5,13 +5,16 @@ const cache = require('./cache');
 const traverseDir = require('./traverse-dir');
 const resolveRootDir = require('./resolve-root-dir');
 
+const DEFAULT_VALID_HELPER_EXTNAMES = ['.js'];
+
 /**
  * Creates a map of helper names to absolute paths to be required.
  * @param {Array} helperDirs - list of absolute paths where helpers are to be found
  * @param {String} rootDir - Jest execution root directory: root of the directory containing the project package.json
+ * @param {Array} helperExtensions - Array of valid javascript filename extensions
  * @returns {Object} - helper module names mapped to their absolute paths
  */
-module.exports = function findHelpers(helperDirs, rootDir) {
+module.exports = function findHelpers(helperDirs, rootDir, helperExtensions = DEFAULT_VALID_HELPER_EXTNAMES) {
   const cachedHelpers = cache.get('foundHelpers');
   if (cachedHelpers) return cachedHelpers;
 
@@ -22,7 +25,7 @@ module.exports = function findHelpers(helperDirs, rootDir) {
       const dir = resolveRootDir(helperDir, rootDir);
       try {
         traverseDir(dir, function(filepath) {
-          if (path.extname(filepath) !== '.js') return;
+          if (!helperExtensions.includes(path.extname(filepath))) return;
 
           const fullHelperPath = path.resolve(dir, filepath);
           const pathFromBaseDir = path.relative(dir, fullHelperPath);
@@ -48,7 +51,7 @@ module.exports = function findHelpers(helperDirs, rootDir) {
 };
 
 function getHelperNameWithoutExtension(filepath) {
-  const basename = path.basename(filepath, '.js');
+  const basename = path.basename(filepath, path.extname(filepath));
   const partialName = filepath
     .split(path.sep)
     .slice(0, -1)


### PR DESCRIPTION
I'm using ES Modules in my project and it would be great if the helper files filenames could also end in `.mjs` instead of `.js`. As these docs say https://nodejs.org/api/esm.html#esm_enabling the `Authors can tell Node.js to treat JavaScript code as ECMAScript modules via the .mjs file extension`.

This PR adds `helperExtensions` config parameter which allows users to define the extensions to search for. It falls back to `*.js`. I modelled this after how the `partialExtensions` parameter had been added.

Tested with Jest.