### PR TITLE
Add missing homepage and bugs fields to handlebars-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/scitech/handlebars-jest.git"
+    "url": "git://github.com/tylergould/handlebars-jest.git"
   },
   "homepage": "https://github.com/scitech/handlebars-jest#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/tylergould/handlebars-jest.git"
+    "url": "git+https://github.com/scitech/handlebars-jest.git"
+  },
+  "homepage": "https://github.com/scitech/handlebars-jest#readme",
+  "bugs": {
+    "url": "https://github.com/scitech/handlebars-jest/issues"
   },
   "author": "Tyler Gould <tg@tylergould.net>",
   "license": "MIT",


### PR DESCRIPTION
This adds the homepage and bugs fields as requested in charles-openclaw/charles-microbounties#1596. The package.json was missing both the README link and issue tracker URL.